### PR TITLE
Fix deprecated name in actions

### DIFF
--- a/.github/workflows/logstash.yml
+++ b/.github/workflows/logstash.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
We have the old name for main branch in the actions file. So merged PRs won't be checked again.